### PR TITLE
Fix broken link in sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
## Description:
- Corrected the typo in `doc-references__.md` → `doc-references.md`.
- Closes #2  # 自动关联并关闭 Issue #2